### PR TITLE
Feat: fix load add thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,61 @@ version = 3
 [[package]]
 name = "lc3-rust"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+thiserror = "2.0.3"
 
 [lints.clippy]
 panic = "deny"

--- a/src/lc3_vm/flags.rs
+++ b/src/lc3_vm/flags.rs
@@ -1,0 +1,16 @@
+#[allow(clippy::upper_case_acronyms)]
+enum ConditionFlags {
+    POS = 0,
+    ZRO = 2,
+    NEG = 4,
+}
+
+impl From<ConditionFlags> for u16 {
+    fn from(val: ConditionFlags) -> Self {
+        match val {
+            ConditionFlags::POS => 0,
+            ConditionFlags::ZRO => 2,
+            ConditionFlags::NEG => 4,
+        }
+    }
+}

--- a/src/lc3_vm/mod.rs
+++ b/src/lc3_vm/mod.rs
@@ -1,2 +1,3 @@
+mod flags;
 mod opcodes;
 pub mod virtual_machine;

--- a/src/lc3_vm/opcodes.rs
+++ b/src/lc3_vm/opcodes.rs
@@ -1,5 +1,5 @@
 #[allow(clippy::upper_case_acronyms)]
-enum Opcodes {
+pub enum Opcode {
     BR,   // branch
     ADD,  // add
     LD,   // load

--- a/src/lc3_vm/virtual_machine.rs
+++ b/src/lc3_vm/virtual_machine.rs
@@ -1,28 +1,16 @@
-use core::{error, fmt};
+use thiserror::Error;
 
+use super::opcodes::Opcode;
 const MEMORY_MAX: usize = 1 << 16;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum VMError {
+    #[error("Failed to load program into memory: {0}")]
     LoadProgram(String),
-}
-
-impl fmt::Display for VMError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::LoadProgram(context) => {
-                write!(f, "Failed to load program into memory: {context}")
-            }
-        }
-    }
-}
-
-impl error::Error for VMError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match *self {
-            VMError::LoadProgram(_) => None,
-        }
-    }
+    #[error("Failed to increment PC: {0}")]
+    ProgramCounter(String),
+    #[error("Failed to fetch instruction {0}")]
+    Fetch(String),
 }
 
 pub struct VM {

--- a/src/lc3_vm/virtual_machine.rs
+++ b/src/lc3_vm/virtual_machine.rs
@@ -28,14 +28,6 @@ pub struct VM {
     count: u16,
 }
 
-#[allow(clippy::upper_case_acronyms)]
-enum ConditionFlags {
-    POS,
-    ZRO,
-    NEG,
-    None,
-}
-
 impl Default for VM {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
**This PR**
- Fix the `load_memory` function it was ignoring the origin address.
- Now the `VMError` uses the thiserror crate
- Change the name from of the enum from `opcodes` to `opcode`
- Move the flags enum to it's own file