### PR TITLE
Feat: refactor, add errors to main, pass filename to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: run build build_release run_release lint clean test
 
+filename ?= ./2048.obj
+
 run:
-	cargo run
+	cargo run -- $(filename)
 
 build:
 	cargo build
@@ -10,7 +12,7 @@ build_release:
 	cargo build --release
 
 run_release:
-	cargo run --release
+	cargo run --release -- $(filename)
 
 lint:
 	cargo clippy

--- a/README.md
+++ b/README.md
@@ -7,14 +7,28 @@ lc3-vm implementation in Rust
 git clone https://github.com/LeanSerra/lc3-rust && cd lc3-rust
 ```
 ### Run
+This will run 2048.obj by default
 ```
 make
 ```
-### Run release mode
+To run your other object files
 ```
-make run_release
+make filename="file_path"
+```
+### Run release mode
+This will run 2048.obj by default
+```
+make release
+```
+To run your other object files
+```
+make release filename="file_path"
 ```
 ### Run tests
 ```
 make test
 ```
+# References
+This project couldn't be possible without the help of this guide:
+
+https://www.jmeiners.com/lc3-vm/

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,24 +5,44 @@ use nix::{
     sys::termios::{tcgetattr, tcsetattr, LocalFlags, SetArg, Termios},
 };
 use std::{
+    env,
     fs::File,
     os::fd::{AsFd, BorrowedFd},
 };
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MainError {
+    #[error("No filename provided")]
+    NoFileName,
+    #[error("Failed to read stdin {0}")]
+    Stdin(String),
+    #[error("Failed to get termios ERRNO: {0}")]
+    GetTermios(String),
+    #[error("Failed to disbale input buffering ERRNO: {0}")]
+    DisableInputBuffering(String),
+    #[error("Failed to restore input buffering ERRNO: {0}")]
+    RestoreInputBuffering(String),
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let stdin_file = File::open("/dev/stdin")?;
+    let file_name = env::args().nth(1).ok_or(MainError::NoFileName)?;
+    let stdin_file = File::open("/dev/stdin").map_err(|err| MainError::Stdin(err.to_string()))?;
     let stdin_fd = AsFd::as_fd(&stdin_file);
-    let mut termios = tcgetattr(stdin_fd)?;
-    let original_termios = disable_input_buffering(stdin_fd, &mut termios)?;
+    let mut termios =
+        tcgetattr(stdin_fd).map_err(|err| MainError::DisableInputBuffering(err.to_string()))?;
+    let original_termios = disable_input_buffering(stdin_fd, &mut termios)
+        .map_err(|err| MainError::DisableInputBuffering(err.to_string()))?;
 
     let mut vm = VM::default();
-    vm.load_program("./2048.obj")?;
+    vm.load_program(&file_name)?;
     vm.running = true;
     while vm.running {
         vm.next_instruction()?;
     }
 
-    restore_input_buffering(stdin_fd, original_termios)?;
+    restore_input_buffering(stdin_fd, original_termios)
+        .map_err(|err| MainError::RestoreInputBuffering(err.to_string()))?;
     Ok(())
 }
 


### PR DESCRIPTION
**This PR**
- Add references to README
- The makefile can now take a `filename` argument to load a custom file to the VM
- Refactor if statement in `read_word` function